### PR TITLE
Add bcc addresses

### DIFF
--- a/lib/google_http_actionmailer.rb
+++ b/lib/google_http_actionmailer.rb
@@ -32,6 +32,11 @@ module GoogleHttpActionmailer
 
     def deliver!(mail)
       user_id = message_options[:user_id] || 'me'
+
+      # Make sure the bcc is included in the headers so any bcc addresses
+      # also get sent
+      mail[:bcc].include_in_headers = true
+
       message = Google::Apis::GmailV1::Message.new(
         raw:       mail.to_s,
         thread_id: mail['Thread-ID'].to_s

--- a/lib/google_http_actionmailer.rb
+++ b/lib/google_http_actionmailer.rb
@@ -35,7 +35,7 @@ module GoogleHttpActionmailer
 
       # Make sure the bcc is included in the headers so any bcc addresses
       # also get sent
-      mail[:bcc].include_in_headers = true
+      mail[:bcc].include_in_headers = true if mail[:bcc]
 
       message = Google::Apis::GmailV1::Message.new(
         raw:       mail.to_s,


### PR DESCRIPTION
It seems bcc headers don't get included the email generated and aren't sent.  This adds the option to tell the mail gem to include the bcc header.